### PR TITLE
Create Flutter project skeleton with Tizen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# handleapp
+# Handleapp
+
+Dette repoet inneholder planleggingen og kildekoden for en kryssplattform
+handleapp som skal fungere på iOS, Samsung Family Hub (Tizen) og på sikt
+Hisense RQ760N4IFE.
+
+## Flutter-prosjekt
+Kildekoden til appen ligger i katalogen [`app/`](app/). Prosjektet er satt opp
+for Flutter med Tizen-støtte gjennom `flutter-tizen` og inneholder en grunnleggende
+layout med tre faner (handleliste, oppskrifter og planlegging) og en
+flytende handlingsknapp for å legge til nye elementer.
+
+### Komme i gang
+1. Installer [Flutter](https://docs.flutter.dev/get-started/install) og
+   [flutter-tizen](https://github.com/flutter-tizen/flutter-tizen#installation).
+2. Fra `app/`-mappen, kjør `flutter-tizen pub get` for å hente avhengigheter.
+3. For å bygge eller kjøre på støttede plattformer:
+   - iOS/Android/Web: `flutter run`
+   - Samsung Family Hub (Tizen): `flutter-tizen run`
+
+## Dokumentasjon
+- [Arkitekturplan](docs/architecture-plan.md)

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,20 @@
+# Flutter/Dart/Pub related
+.dart_tool/
+.packages
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+.melos_tool
+.idea/
+.vscode/
+
+# IntelliJ
+*.iml
+*.ipr
+*.iws
+
+# VS Code
+*.code-workspace
+
+# Flutter
+pubspec.lock

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,17 @@
+# HandleApp Flutter-prosjekt
+
+Dette er grunnprosjektet for HandleApp bygget med Flutter. Prosjektet er
+initialisert manuelt for å støtte både standard Flutter-mål og Samsung Family
+Hub via Tizen.
+
+## Struktur
+- `lib/main.dart`: Material 3-basert layout med tre faner som viser de viktigste
+  funksjonsområdene for appen.
+- `tizen/`: Grunnleggende konfigurasjon for å bygge prosjektet med
+  `flutter-tizen`.
+- `test/`: En enkel plassholdertest for å bekrefte oppsettet.
+
+## Neste steg
+- Integrere tilstandsforvaltning og datasynkronisering.
+- Legge til faktiske skjermbilder og komponenter for handleliste og oppskrifter.
+- Utvide Tizen-konfigurasjonen med riktige ikoner, sertifikater og privilegier.

--- a/app/analysis_options.yaml
+++ b/app/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    avoid_print: true

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -1,0 +1,225 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const HandleApp());
+}
+
+class HandleApp extends StatelessWidget {
+  const HandleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'HandleApp',
+      theme: ThemeData(
+        colorScheme: ColorScheme.fromSeed(seedColor: const Color(0xFF2A9D8F)),
+        useMaterial3: true,
+      ),
+      home: const ShoppingHomePage(),
+    );
+  }
+}
+
+class ShoppingHomePage extends StatefulWidget {
+  const ShoppingHomePage({super.key});
+
+  @override
+  State<ShoppingHomePage> createState() => _ShoppingHomePageState();
+}
+
+class _ShoppingHomePageState extends State<ShoppingHomePage> {
+  int _selectedIndex = 0;
+
+  final List<String> _tabs = const [
+    'Handleliste',
+    'Oppskrifter',
+    'Planlegging',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(_tabs[_selectedIndex]),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: _buildBody(),
+      ),
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: _selectedIndex,
+        onDestinationSelected: (index) {
+          setState(() {
+            _selectedIndex = index;
+          });
+        },
+        destinations: const [
+          NavigationDestination(
+            icon: Icon(Icons.shopping_cart_outlined),
+            selectedIcon: Icon(Icons.shopping_cart),
+            label: 'Handleliste',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.receipt_long_outlined),
+            selectedIcon: Icon(Icons.receipt_long),
+            label: 'Oppskrifter',
+          ),
+          NavigationDestination(
+            icon: Icon(Icons.event_note_outlined),
+            selectedIcon: Icon(Icons.event_note),
+            label: 'Planlegging',
+          ),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          // TODO: implement item creation flow
+        },
+        icon: const Icon(Icons.add),
+        label: const Text('Nytt element'),
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    switch (_selectedIndex) {
+      case 0:
+        return const _ShoppingListPlaceholder();
+      case 1:
+        return const _RecipesPlaceholder();
+      case 2:
+        return const _PlanningPlaceholder();
+      default:
+        return const SizedBox.shrink();
+    }
+  }
+}
+
+class _ShoppingListPlaceholder extends StatelessWidget {
+  const _ShoppingListPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Dine favorittbutikker',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 12),
+        Expanded(
+          child: ListView(
+            children: const [
+              _PlaceholderCard(
+                title: 'Ukens handleliste',
+                description: 'Legg til varer og synkroniser på tvers av enheter.',
+                icon: Icons.list_alt,
+              ),
+              _PlaceholderCard(
+                title: 'Delte lister',
+                description: 'Inviter familien og hold alle oppdatert i sanntid.',
+                icon: Icons.group_outlined,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _RecipesPlaceholder extends StatelessWidget {
+  const _RecipesPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Oppskrifter',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 12),
+        const Expanded(
+          child: Center(
+            child: Text('Oppskriftsintegrasjon kommer i neste iterasjon.'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlanningPlaceholder extends StatelessWidget {
+  const _PlanningPlaceholder();
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Planlegging',
+          style: Theme.of(context).textTheme.titleLarge,
+        ),
+        const SizedBox(height: 12),
+        const Expanded(
+          child: Center(
+            child: Text('Måltidsplanlegging og kalenderkobling kommer snart.'),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PlaceholderCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final IconData icon;
+
+  const _PlaceholderCard({
+    required this.title,
+    required this.description,
+    required this.icon,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: Theme.of(context).colorScheme.outlineVariant),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(20.0),
+        child: Row(
+          children: [
+            Icon(icon, size: 36, color: Theme.of(context).colorScheme.primary),
+            const SizedBox(width: 20),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    description,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -1,0 +1,21 @@
+name: handleapp
+version: 0.1.0+1
+description: "HandleApp - tverrplattform handleliste for iOS, Family Hub og Tizen"
+publish_to: 'none'
+
+environment:
+  sdk: ">=3.0.0 <4.0.0"
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.6
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.0
+
+flutter:
+  uses-material-design: true

--- a/app/test/widget_test.dart
+++ b/app/test/widget_test.dart
@@ -1,0 +1,7 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('placeholder test', () {
+    expect(1 + 1, equals(2));
+  });
+}

--- a/app/tizen/flutter_tizen.yaml
+++ b/app/tizen/flutter_tizen.yaml
@@ -1,0 +1,14 @@
+app:
+  package: org.handleapp.shopping
+  label: HandleApp
+  version: 0.1.0
+  tizen-sdk: 8.0
+  ui-application: true
+  screen-orientation: landscape
+
+flutter:
+  target: lib/main.dart
+  enable-software-rendering: false
+
+profile:
+  device-profile: familyhub

--- a/app/tizen/project_def.prop
+++ b/app/tizen/project_def.prop
@@ -1,0 +1,7 @@
+APPNAME = HandleApp
+APPID = org.handleapp.shopping
+TYPE = uiapp
+PROFILE = common
+API_VERSION = 8
+SECURE_ID = b7QnIzsJ2W
+DISTRO = tizen

--- a/app/tizen/tizen-manifest.xml
+++ b/app/tizen/tizen-manifest.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.handleapp.shopping" version="0.1.0" api-version="8">
     <profile name="common"/>
-    <service-application appid="org.handleapp.shopping" exec="HandleApp" multiple="false" nodisplay="false">
+    <ui-application appid="org.handleapp.shopping" exec="HandleApp" multiple="false" nodisplay="false">
         <label>HandleApp</label>
         <icon>res/icons/app.png</icon>
         <metadata key="flutter" value="true"/>
-    </service-application>
+    </ui-application>
     <privileges>
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>

--- a/app/tizen/tizen-manifest.xml
+++ b/app/tizen/tizen-manifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="org.handleapp.shopping" version="0.1.0" api-version="8">
+    <profile name="common"/>
+    <service-application appid="org.handleapp.shopping" exec="HandleApp" multiple="false" nodisplay="false">
+        <label>HandleApp</label>
+        <icon>res/icons/app.png</icon>
+        <metadata key="flutter" value="true"/>
+    </service-application>
+    <privileges>
+        <privilege>http://tizen.org/privilege/internet</privilege>
+        <privilege>http://tizen.org/privilege/network.get</privilege>
+    </privileges>
+</manifest>

--- a/docs/architecture-plan.md
+++ b/docs/architecture-plan.md
@@ -1,0 +1,69 @@
+# Handleapp Architecture Plan
+
+## Overview
+Dette dokumentet skisserer en første arkitektur for en handleapp som skal
+fungerer på iOS og Samsung Family Hub-kjøleskap, og senere integreres med
+Hisense RQ760N4IFE side-by-side kjøleskap. Fokus er på en fleksibel og
+fremtidssikker løsning som kan videreutvikles i iterasjoner.
+
+## Mål
+- **Kryssplattform**: En felles kodebase for iOS og Samsung Family Hub (Tizen)
+  med støtte for fremtidige Hisense-enheter.
+- **Offline-first**: Sømløs brukeropplevelse selv uten nett.
+- **Utvidbar**: Arkitektur som gjør det enkelt å koble på nye tjenester og
+enheter.
+- **Sikker**: Sikre brukerdata og autentisering.
+
+## Teknologistack
+- **Frontend**: Flutter med Tizen-støtte. Flutter gir native-lignende
+  opplevelser på iOS og har et voksende økosystem for Tizen. Vi kan benytte
+  `flutter-tizen` for å bygge til Samsung Family Hub.
+- **Backend/API**: Cloud-basert GraphQL/REST API (f.eks. Firebase, Supabase
+  eller egen Node/Go backend) for synkronisering mellom enheter.
+- **Database lokalt**: SQLite via `sqflite` (Flutter) for offline caching.
+- **State management**: Riverpod eller Bloc for strukturert state-håndtering.
+- **Autentisering**: OAuth 2.0/OpenID Connect med støtte for Apple ID og
+  Samsung Account, samt e-post/telefon.
+
+## Arkitektur
+1. **Presentasjonslag**
+   - Delte Flutter-widgets optimalisert for ulike skjermstørrelser.
+   - Responsivt design med støtte for pekeskjerm (Family Hub) og touch (mobil).
+2. **State-lag**
+   - Riverpod-providers som kapsler API-kall og lokal state.
+3. **Data-lag**
+   - Repositories som synker med backend og lagrer i lokal database.
+4. **Integrasjonslag**
+   - Abstrakte services for hvitevarer. Start med en generisk adapter og
+     implementer konkrete klasser for Samsung og senere Hisense.
+
+## Funksjonalitetsplan (MVP)
+1. **Brukerhåndtering**
+   - Registrering, innlogging og profil.
+2. **Handlelister**
+   - Opprette, dele og redigere lister.
+   - Felles sanntidsoppdatering via backend.
+3. **Produktkatalog**
+   - Søke etter varer, kategorier og forslag.
+4. **Kjøleskapsintegrasjon (fase 2)**
+   - Lesing av sensor-/lagerdata der tilgjengelig.
+   - Push-varsler til appen ved lav beholdning.
+
+## Enhetsspesifikke hensyn
+- **iOS**: Følge Apple Human Interface Guidelines. Bruke Sign in with Apple.
+- **Samsung Family Hub**: Tizen-app med fokus på stor skjerm. Navigasjon via
+  pekeskjerm og fysiske knapper. Optimaliser for liggende modus.
+- **Hisense RQ760N4IFE**: Kartlegg API-er/SDK når tilgjengelig. Planlegg for
+  modulbasert integrasjon som kan kobles på uten å endre kjernefunksjonalitet.
+
+## Distribusjon
+- CI/CD med GitHub Actions som bygger Flutter-apper for iOS (via Codemagic el.
+  lignende) og Tizen (docker-baserte bygg).
+- Feature flag-system for gradvis utrulling av nye integrasjoner.
+
+## Neste steg
+1. Opprette Flutter-prosjekt med Tizen-støtte og basislayout.
+2. Definere datamodeller for handleliste, bruker og enhetsintegrasjon.
+3. Velge backend-løsning (MVP: Firebase Firestore) og sette opp første API.
+4. Sette opp CI/CD pipeline for bygg og tester.
+


### PR DESCRIPTION
## Summary
- add a Flutter project skeleton under `app/` with Material 3 shopping layout tabs
- define initial Tizen configuration files for running on Samsung Family Hub
- document project structure and setup steps in the root and app readme files

## Testing
- not run (Flutter tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d688c3d1908332bd808dcb2b5cd10a